### PR TITLE
Fix README instructions on how to run cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ fetch("https://api.openai.com/v1/engines/text-curie-001/completions", {
 
 ## Application In Use
 
-![App Screenshot](assets/app-in-use.gif)
+![Application GIF](assets/app-in-use.gif)
 
 
 ## Running Tests
@@ -71,7 +71,7 @@ fetch("https://api.openai.com/v1/engines/text-curie-001/completions", {
 To run tests, run the following command
 
 ```bash
-  npm run test
+  npm run cypress
 ```
 
 


### PR DESCRIPTION
#### What's this PR do?
- Changes the CLI instructions for testing so that it instructs using `npm run cypress`

#### Where should the reviewer start?
- README/md

#### How should this be manually tested?
- Read through README.md